### PR TITLE
Add a separate job to prepare managed node

### DIFF
--- a/plans/general.fmf
+++ b/plans/general.fmf
@@ -20,38 +20,31 @@ environment:
     LINUXSYSTEMROLES_SSH_KEY: ""
     ARTIFACTS_DIR: ""
     ARTIFACTS_URL: ""
+    LSR_DEBUG: true
 prepare:
   - name: Use vault.centos.org repos (CS 7, 8 EOL workaround)
     script: |
       if grep -q -e 'CentOS Stream release 8' -e 'CentOS Linux release 7.9' /etc/redhat-release; then
         sed -i '/^mirror/d;s/#\(baseurl=http:\/\/\)mirror/\1vault/' /etc/yum.repos.d/*.repo
       fi
-  - name: Enable epel to install beakerlib on all platforms except CS10 and Fedora, there it's not available and not needed
+  - name: Enable epel to install beakerlib on all platforms except CS10 and Fedora, there epel not available and not needed
     script: |
       if ! grep -q -e 'CentOS Stream release 10' -e 'Fedora release' /etc/redhat-release; then
         yum install epel-release -y
       fi
-    where: control_node
-  - name: Install python on managed node when running CS8 with ansible!=2.9
-    script: |
-      if [ "$ANSIBLE_VER" != "2.9" ] && grep -q 'CentOS Stream release 8' /etc/redhat-release; then
-        dnf install -y python"$PYTHON_VERSION"
-      fi
-    where: managed_node
-  - name: Distribute SSH keys when provisioned with how=virtual
-    script: |
-      if [ -f ${TMT_TREE%/*}/provision/control_node/id_ecdsa.pub ]; then
-        cat ${TMT_TREE%/*}/provision/control_node/id_ecdsa.pub >> ~/.ssh/authorized_keys
-      fi
-    where: managed_node
 discover:
-  - name: Run test playbooks from control_node
+  - name: Prepare managed node
     how: fmf
-    # url no needed when running from the tft-tests repository
+    # url not needed when running from the tft-tests repository
     # url: https://github.com/linux-system-roles/tft-tests
     # ref: main
-    # url: https://github.com/spetrosi/tft-tests
-    # ref: add-tmt-tests
+    where: managed_node
+    filter: tag:prep_managed_node
+  - name: Run test playbooks from control_node
+    how: fmf
+    # url not needed when running from the tft-tests repository
+    # url: https://github.com/linux-system-roles/tft-tests
+    # ref: main
     where: control_node
     filter: tag:test_playbooks
 execute:

--- a/tests/general/main.fmf
+++ b/tests/general/main.fmf
@@ -8,7 +8,3 @@ require:
     - git
     # Required for yq
     - jq
-    - type: library
-      url: https://github.com/linux-system-roles/tft-tests
-      ref: main
-      name: /library

--- a/tests/prep_managed_node/main.fmf
+++ b/tests/prep_managed_node/main.fmf
@@ -1,0 +1,10 @@
+summary: Prepare managed node
+framework: beakerlib
+test: ./prep_managed_node.sh
+duration: 15min
+tag: prep_managed_node
+require:
+    - beakerlib
+    - git
+    # Required for yq
+    - jq

--- a/tests/prep_managed_node/prep_managed_node.sh
+++ b/tests/prep_managed_node/prep_managed_node.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+# Test parameters:
+# REPO_NAME
+#   Name of the role repository to test.
+#
+# GITHUB_ORG
+#   Optional: GitHub org to fetch test repository from. Default: linux-system-roles. Can be set to a fork for test purposes.
+GITHUB_ORG="${GITHUB_ORG:-linux-system-roles}"
+# REQUIRED_VARS
+#   Env variables required by this test
+REQUIRED_VARS=("REPO_NAME")
+# PYTHON_VERSION
+#   Python version to install ansible-core with (EL 8, 9, 10 only).
+
+tmt_tree_provision=${TMT_TREE%/*}/provision
+role_path=$TMT_TREE/$REPO_NAME
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "rlImport library"
+        for required_var in "${REQUIRED_VARS[@]}"; do
+            if [ -z "${!required_var}" ]; then
+                rlDie "This required variable is unset: $required_var "
+            fi
+        done
+        rolesCS8InstallPython
+        rolesDistributeSSHKeys "$tmt_tree_provision"
+        rolesEnableHA
+        rolesDisableNFV
+        rolesGenerateTestDiscs "$role_path"
+    rlPhaseEnd
+rlJournalEnd


### PR DESCRIPTION
Managed node preparation requires more complicated structure than oneliners in FMF plan, this PR creates a separate FMF test to be run on managed nodes to prepare for tests.