### PR TITLE
Install passlib

### DIFF
--- a/library/lib.sh
+++ b/library/lib.sh
@@ -20,12 +20,12 @@ rolesInstallAnsible() {
     fi
     if rlIsFedora || (rlIsRHELLike ">7" && [ "$ANSIBLE_VER" != "2.9" ]); then
         rlRun "dnf install python$PYTHON_VERSION-pip -y"
-        rlRun "python$PYTHON_VERSION -m pip install ansible-core==$ANSIBLE_VER.*"
+        rlRun "python$PYTHON_VERSION -m pip install ansible-core==$ANSIBLE_VER.* passlib"
     elif rlIsRHELLike 8; then
         PYTHON_VERSION=3.9
         rlRun "dnf install python$PYTHON_VERSION -y"
         # selinux needed for delegate_to: localhost for file, copy, etc.
-        rlRun "python$PYTHON_VERSION -m pip install ansible==$ANSIBLE_VER.* selinux"
+        rlRun "python$PYTHON_VERSION -m pip install ansible==$ANSIBLE_VER.* selinux passlib"
     else
         # el7
         rlRun "yum install ansible-$ANSIBLE_VER.* -y"


### PR DESCRIPTION
Ansible 2.17 shows that password_hash filter is going to be deprecated since Ansible 2.19.
I noticed this because passlib, a requirement for password_hash, is not pulled when installing ansible-2.17 with pip.
Apparently, passlib is not being supported, three years without commits. More info in ansible/ansible#81949 and in ansible/ansible#82652. We can use some cli like mkpasswd instead.