### PR TITLE
support GET_PYTHON_MODULES - gather python module usage information

### DIFF
--- a/tests/general/process_python_modules_packages.yml
+++ b/tests/general/process_python_modules_packages.yml
@@ -1,0 +1,47 @@
+---
+- name: Get python modules from log file and create packages file
+  hosts: all
+  gather_facts: false
+  vars:
+    logfile: ""
+    packages_file: packages.txt
+  tasks:
+    - name: Get list of modules
+      set_fact:
+        modules: "{{ lookup('file', logfile).splitlines() | select('match', __pat) |
+          map('regex_replace', __pat, '\\1') | select | union(modules | d([])) | unique | list }}"
+      vars:
+        __pat: "^>>># /[^ ]+ matches (/[^ ]+?[.]py).*$"
+      changed_when: false
+      delegate_to: localhost
+
+    - name: Copy modules file to host
+      copy:
+        content: "{{ modules | sort | join(__nl) ~ __nl }}"
+        dest: /tmp/modules.txt
+        mode: "0600"
+      vars:
+        __nl: "\n"
+
+    - name: Get unique list of packages that provide modules in modules.txt
+      shell: |
+        declare -A packages
+        while read -r file; do
+          if [ -z "$file" ]; then
+            continue  # probably extra trailing newline
+          elif pkg="$(rpm -qf "$file" --queryformat '%{name}-%{version}-%{release}\n')"; then
+            packages["$pkg"]="$pkg"
+          else
+            echo "ERROR: file $file does not belong to any package"
+          fi
+        done < /tmp/modules.txt
+        for pkg in "${packages[@]}"; do
+          echo "$pkg"
+        done | sort > /tmp/packages.txt
+      changed_when: false
+
+    - name: Copy packages file back to localhost
+      fetch:
+        src: /tmp/packages.txt
+        dest: "{{ packages_file }}"
+        flat: true

--- a/tests/general/test.sh
+++ b/tests/general/test.sh
@@ -63,6 +63,10 @@ rlJournalStart
         done
         rolesInstallAnsible
         rolesInstallYq
+        if [ "${ANSIBLE_VER:-}" = 2.9 ]; then
+            # does not work with 2.9
+            GET_PYTHON_MODULES=false
+        fi
         rolesGetRoleDir
         # role_path is defined in rolesGetRoleDir
         # shellcheck disable=SC2154
@@ -84,10 +88,14 @@ rlJournalStart
         # shellcheck disable=SC2154
         inventory=$(rolesPrepareInventoryVars "$role_path" "$tmt_tree_provision" "$guests_yml")
         rlRun "cat $inventory"
+        tests_path="$collection_path"/ansible_collections/fedora/linux_system_roles/tests/"$REPO_NAME"/
+        if [ "${GET_PYTHON_MODULES:-}" = true ]; then
+            # shellcheck disable=SC2086
+            rolesSetupGetPythonModules "$tests_path" $test_playbooks
+        fi
     rlPhaseEnd
     rlPhaseStartTest
         managed_nodes=$(rolesGetManagedNodes "$guests_yml")
-        tests_path="$collection_path"/ansible_collections/fedora/linux_system_roles/tests/"$REPO_NAME"/
         rolesRunPlaybooksParallel "$tests_path" "$inventory" "$SKIP_TAGS" "$test_playbooks" "$managed_nodes"
     rlPhaseEnd
 rlJournalEnd


### PR DESCRIPTION
Run ansible with ANSIBLE_DEBUG=true and run each playbook with
PYTHONVERBOSE=1 in order to trace python module execution, so
that we can determine which python packages are required to run
each role.
