### PR TITLE
TEST_ROLES must be single line json

### DIFF
--- a/.github/workflows/get_python_modules.yml
+++ b/.github/workflows/get_python_modules.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set variables used by all tests
         id: set_vars
         run: |
-          echo "TEST_ROLES=$TEST_ROLES" >> $GITHUB_OUTPUT
+          echo "TEST_ROLES=${{ toJSON(fromJSON(env.TEST_ROLES)) }}" >> $GITHUB_OUTPUT
 
   prepare_role_vars:
     name: Get info from test roles


### PR DESCRIPTION
Convert TEST_ROLES from json, then back to json, to ensure it can
be used as a variable in the correct format.
