### PR TITLE
support testing on image mode systems

### DIFF
--- a/library/lib.sh
+++ b/library/lib.sh
@@ -702,7 +702,7 @@ lsrGetOstreePackages() {
     collection_path="$1"
     node_platform="$2"
     distro="${node_platform%%-*}"
-    if [[ "$node_platform" =~ ([a-zA-Z_-]+)-([0-9]+) ]]; then
+    if [[ "$node_platform" =~ ^([a-zA-Z_-]+)-([0-9]+) ]]; then
         distro="${BASH_REMATCH[1]}"
         ver="${BASH_REMATCH[2]}"
         case "$distro" in

--- a/tests/general/test.sh
+++ b/tests/general/test.sh
@@ -124,6 +124,7 @@ rlJournalStart
             # shellcheck disable=SC2086
             lsrSetupGetPythonModules "$test_playbooks"
         fi
+        lsrPrepareImageMode "$collection_path"
     rlPhaseEnd
     rlPhaseStartTest
         managed_nodes=$(lsrGetManagedNodes "$guests_yml")


### PR DESCRIPTION
Support testing managed nodes which use Image Mode.
Get the list of packages to install on the system using get_ostree_data.sh
Install the packages on the managed node using rpm-ostree install.
Reboot the managed node and wait for it to be ready.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
