### PR TITLE
test: sort test files in alphanum order

### DIFF
--- a/library/lib.sh
+++ b/library/lib.sh
@@ -80,7 +80,7 @@ lsrGetRoleDir() {
 lsrGetTests() {
     local tests_path=$1
     local test_playbooks_all test_playbooks
-    test_playbooks_all=$(find "$tests_path" -maxdepth 1 -type f -name "tests_*.yml")
+    test_playbooks_all=$(find "$tests_path" -maxdepth 1 -type f -name "tests_*.yml" | sort)
     if [ -n "$SR_ONLY_TESTS" ]; then
         for test_playbook in $test_playbooks_all; do
             playbook_basename=$(basename "$test_playbook")


### PR DESCRIPTION
The order returned by `find` is not guaranteed to be in any
order, and may change between PRs.  This makes it difficult to reproduce
CI test runs.  If some failures are test order dependent, then
you may see failures in a PR that you did not see in previous PRs.
A stable test order is needed.  The `sort` command will sort in
alphanum (ASCII) order.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
