### PR TITLE
ci: support lsr_report_errors.py callback for error reporting in log

### DIFF
--- a/library/lib.sh
+++ b/library/lib.sh
@@ -204,6 +204,7 @@ lsrInstallDependencies() {
 lsrEnableCallbackPlugins() {
     local collection_path=$1
     local cmd
+    local basename
     # Enable callback plugins for prettier ansible output
     callback_path=ansible_collections/ansible/posix/plugins/callback
     if [ ! -f "$collection_path"/"$callback_path"/debug.py ] || [ ! -f "$collection_path"/"$callback_path"/profile_tasks.py ]; then
@@ -228,6 +229,10 @@ lsrEnableCallbackPlugins() {
         ANSIBLE_ENVS[ANSIBLE_CALLBACK_WHITELIST]="profile_tasks"
     fi
     ANSIBLE_ENVS[ANSIBLE_STDOUT_CALLBACK]="debug"
+    # grab the lsr_report_errors.py callback plugin
+    basename="$(basename "$SR_REPORT_ERRORS_URL")"
+    curl -L -s -o "$collection_path/$callback_path/$basename" "$SR_REPORT_ERRORS_URL"
+    ANSIBLE_ENVS[ANSIBLE_CALLBACK_PLUGINS]="$collection_path/$callback_path"
 }
 
 lsrConvertToCollection() {

--- a/tests/general/test.sh
+++ b/tests/general/test.sh
@@ -79,6 +79,10 @@ SR_REQUIRED_VARS=("SR_ANSIBLE_VER" "SR_REPO_NAME")
 #   Default is "-vv" - user can locally edit tft.yml in role to increase this for debugging
 [ -n "$LSR_ANSIBLE_VERBOSITY" ] && export SR_ANSIBLE_VERBOSITY="$LSR_ANSIBLE_VERBOSITY"
 SR_ANSIBLE_VERBOSITY="${SR_ANSIBLE_VERBOSITY:--vv}"
+# SR_REPORT_ERRORS_URL
+#   Default is https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/main/callback_plugins/lsr_report_errors.py
+#   This is used to embed an error report in the output log
+SR_REPORT_ERRORS_URL="${SR_REPORT_ERRORS_URL:-https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/main/callback_plugins/lsr_report_errors.py}"
 
 rlJournalStart
     rlPhaseStartSetup

--- a/tests/mssql_ha/mssql_ha.sh
+++ b/tests/mssql_ha/mssql_ha.sh
@@ -81,6 +81,10 @@ SR_REQUIRED_VARS=("SR_ANSIBLE_VER" "SR_REPO_NAME")
 #   Default is "-vv" - user can locally edit tft.yml in role to increase this for debugging
 [ -n "$LSR_ANSIBLE_VERBOSITY" ] && export SR_ANSIBLE_VERBOSITY="$LSR_ANSIBLE_VERBOSITY"
 SR_ANSIBLE_VERBOSITY="${SR_ANSIBLE_VERBOSITY:--vv}"
+# SR_REPORT_ERRORS_URL
+#   Default is https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/main/callback_plugins/lsr_report_errors.py
+#   This is used to embed an error report in the output log
+SR_REPORT_ERRORS_URL="${SR_REPORT_ERRORS_URL:-https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/main/callback_plugins/lsr_report_errors.py}"
 
 rlJournalStart
     rlPhaseStartSetup


### PR DESCRIPTION
Set up the callback plugin lsr_report_errors.py to collect the test
errors in the test log file.

See https://github.com/linux-system-roles/auto-maintenance/pull/376

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

CI:
- Added support for downloading and enabling the lsr_report_errors.py callback plugin in the test infrastructure