### PR TITLE
Fix mssql_version regex

### DIFF
--- a/tests/mssql_ha/mssql_ha.sh
+++ b/tests/mssql_ha/mssql_ha.sh
@@ -163,8 +163,8 @@ rlJournalStart
             test_playbook_basename=$(basename "$test_playbook")
             for mssql_version in $supported_versions; do
                 # Replace mssql_version value to one of the supported versions
-                sed -i "s/mssql_version.*$/mssql_version: $mssql_version/g" "$test_playbook"
-                rlRun "grep '^ *mssql_version:' $test_playbook"
+                sed -i "s/mssql_version: [0-9]*$/mssql_version: $mssql_version/g" "$test_playbook"
+                rlRun "grep 'mssql_version: [0-9]*$' $test_playbook"
                 # tmt_plan is assigned at lsrPrepTestVars
                 # shellcheck disable=SC2154
                 LOGFILE="${test_playbook_basename%.*}"-ANSIBLE-"$SR_ANSIBLE_VER"-"$tmt_plan"-"$mssql_version"


### PR DESCRIPTION
## Summary by Sourcery

Refine the mssql_version regex in the HA test script to match only numeric version strings at the end of the line.

Bug Fixes:
- Tighten the sed substitution pattern to replace only numeric mssql_version assignments
- Update the grep check to assert a numeric version at the end of the mssql_version line

Tests:
- Adjust regex patterns in tests/mssql_ha/mssql_ha.sh for version replacement and validation