### PR TITLE
ci: Skip tests::bootc-e2e

### DIFF
--- a/tests/general/test.sh
+++ b/tests/general/test.sh
@@ -57,7 +57,7 @@ SR_PYTHON_VERSION="${SR_PYTHON_VERSION:-3.12}"
 # SR_SKIP_TAGS
 #   Ansible tags that must be skipped
 [ -n "$SKIP_TAGS" ] && export SR_SKIP_TAGS="$SKIP_TAGS"
-SR_SKIP_TAGS="--skip-tags tests::nvme,tests::infiniband"
+SR_SKIP_TAGS="--skip-tags tests::nvme,tests::infiniband,tests::bootc-e2e"
 # SR_TFT_DEBUG
 #   Print output of ansible playbooks to terminal in addition to printing it to logfile
 [ -n "$LSR_TFT_DEBUG" ] && export SR_TFT_DEBUG="$LSR_TFT_DEBUG"

--- a/tests/mssql_ha/mssql_ha.sh
+++ b/tests/mssql_ha/mssql_ha.sh
@@ -59,7 +59,7 @@ SR_PYTHON_VERSION="${SR_PYTHON_VERSION:-3.12}"
 # SR_SKIP_TAGS
 #   Ansible tags that must be skipped
 [ -n "$SKIP_TAGS" ] && export SR_SKIP_TAGS="$SKIP_TAGS"
-SR_SKIP_TAGS="--skip-tags tests::nvme,tests::infiniband"
+SR_SKIP_TAGS="--skip-tags tests::nvme,tests::infiniband,tests::bootc-e2e"
 # SR_TFT_DEBUG
 #   Print output of ansible playbooks to terminal in addition to printing it to logfile
 [ -n "$LSR_TFT_DEBUG" ] && export SR_TFT_DEBUG="$LSR_TFT_DEBUG"
@@ -177,4 +177,3 @@ rlJournalStart
         done
     rlPhaseEnd
 rlJournalEnd
-


### PR DESCRIPTION
These tests are specifically designed to validate a bootc container build → qcow conversion → validation in QEMU deployment end-to-end workflow. These are not currently possible to do in TF [1], and once they are, they need to be treated specially in our test plan.

[1] https://issues.redhat.com/browse/RHEL-85667

---

Noticed in https://github.com/linux-system-roles/crypto_policies/pull/153 , see [TF failing result](https://dl.fedoraproject.org/pub/alt/linuxsystemroles/logs/tf_crypto_policies-153_CentOS-Stream-9-2.17_20250606-045229/artifacts/)

## Summary by Sourcery

CI:
- Exclude bootc-e2e end-to-end tests from the CI by appending 'tests::bootc-e2e' to the SR_SKIP_TAGS in tests/general/test.sh