### PR TITLE
Add tests::bootc-e2e to skip tags

### DIFF
--- a/tests/general/test.sh
+++ b/tests/general/test.sh
@@ -57,7 +57,7 @@ SR_PYTHON_VERSION="${SR_PYTHON_VERSION:-3.12}"
 # SR_SKIP_TAGS
 #   Ansible tags that must be skipped
 [ -n "$SKIP_TAGS" ] && export SR_SKIP_TAGS="$SKIP_TAGS"
-SR_SKIP_TAGS="--skip-tags tests::nvme,tests::infiniband"
+SR_SKIP_TAGS="--skip-tags tests::nvme,tests::infiniband,tests::bootc-e2e"
 # SR_TFT_DEBUG
 #   Print output of ansible playbooks to terminal in addition to printing it to logfile
 [ -n "$LSR_TFT_DEBUG" ] && export SR_TFT_DEBUG="$LSR_TFT_DEBUG"

--- a/tests/mssql_ha/mssql_ha.sh
+++ b/tests/mssql_ha/mssql_ha.sh
@@ -59,7 +59,7 @@ SR_PYTHON_VERSION="${SR_PYTHON_VERSION:-3.12}"
 # SR_SKIP_TAGS
 #   Ansible tags that must be skipped
 [ -n "$SKIP_TAGS" ] && export SR_SKIP_TAGS="$SKIP_TAGS"
-SR_SKIP_TAGS="--skip-tags tests::nvme,tests::infiniband"
+SR_SKIP_TAGS="--skip-tags tests::nvme,tests::infiniband,tests::bootc-e2e"
 # SR_TFT_DEBUG
 #   Print output of ansible playbooks to terminal in addition to printing it to logfile
 [ -n "$LSR_TFT_DEBUG" ] && export SR_TFT_DEBUG="$LSR_TFT_DEBUG"


### PR DESCRIPTION
## Summary by Sourcery

Add the 'tests::bootc-e2e' tag to the default skipped Ansible test tags in test scripts

Tests:
- Include 'tests::bootc-e2e' in SR_SKIP_TAGS for general test.sh
- Include 'tests::bootc-e2e' in SR_SKIP_TAGS for mssql_ha test script