### PR TITLE
support the pip install --pre flag for ansible-core 2.19 pre-release

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -115,7 +115,7 @@ jobs:
           - platform: Fedora-41
             ansible_version: 2.17
           - platform: Fedora-42
-            ansible_version: 2.17
+            ansible_version: 2.19
           - platform: CentOS-7-latest
             ansible_version: 2.9
           - platform: CentOS-Stream-8

--- a/library/lib.sh
+++ b/library/lib.sh
@@ -37,7 +37,7 @@ lsrInstallAnsible() {
 
     if rlIsFedora || (rlIsRHELLike ">7" && [ "$SR_ANSIBLE_VER" != "2.9" ]); then
         rlRun "dnf install python$SR_PYTHON_VERSION-pip -y"
-        rlRun "python$SR_PYTHON_VERSION -m pip install ansible-core==$SR_ANSIBLE_VER.* passlib"
+        rlRun "python$SR_PYTHON_VERSION -m pip install --pre ansible-core==$SR_ANSIBLE_VER.* passlib"
     elif rlIsRHELLike 8; then
         # el8 ansible-2.9
         rlRun "dnf install python$SR_PYTHON_VERSION -y"


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Include the --pre option in the pip installation command for ansible-core to support pre-release packages.