### PR TITLE
For mssql_ha, run one more test playbook from #338

### DIFF
--- a/library/lib.sh
+++ b/library/lib.sh
@@ -666,9 +666,13 @@ lsrGenerateTestDisks() {
     done
 }
 
-lsrMssqlHaUpdateInventory() {
+lsrAppendHostVarsToInventory() {
     local keys values key value
     local inventory=$1
+    # Name of array where:
+    #   name or array - name a managed node to set vars for
+    #   keys - managed nodes to set vars for
+    #   values - vars values
     local arr_name=$2
     eval "keys=(\${!${arr_name}[@]})"
     eval "values=(\${${arr_name}[@]})"

--- a/plans/mssql_ha.fmf
+++ b/plans/mssql_ha.fmf
@@ -37,7 +37,7 @@ environment:
     PYTHON_VERSION: 3.12
     SR_REPO_NAME: mssql
     # new var name: SR_ONLY_TESTS: ""
-    # SYSTEM_ROLES_ONLY_TESTS: "tests_configure_ha_cluster_external.yml tests_configure_ha_cluster_read_scale.yml tests_configure_ha_cluster_external_read_only.yml"
+    SYSTEM_ROLES_ONLY_TESTS: "tests_configure_ha_cluster_external.yml tests_configure_ha_cluster_read_scale.yml tests_configure_ha_cluster_external_read_only.yml"
     SR_TEST_LOCAL_CHANGES: false
     SR_PR_NUM: ""
     SR_LSR_USER: ""

--- a/tests/mssql_ha/mssql_ha.sh
+++ b/tests/mssql_ha/mssql_ha.sh
@@ -120,37 +120,39 @@ rlJournalStart
         inventory_read_scale=$(lsrPrepareInventoryVars "$tmt_tree_provision" "$guests_yml")
         inventory_external_read_only=$(lsrPrepareInventoryVars "$tmt_tree_provision" "$guests_yml")
 
-        # Set mssql_ha_repolica_type variables in inventories
+        # Set mssql_ha_replica_type variables in inventories
         declare -A mssql_ha_replica_type
         mssql_ha_replica_type[managed-node1]=primary
         mssql_ha_replica_type[managed-node2]=synchronous
-        # mssql_ha_replica_type is used below when calling lsrMssqlHaUpdateInventory
+        # mssql_ha_replica_type is used below when calling lsrAppendHostVarsToInventory
         # shellcheck disable=SC2034
         mssql_ha_replica_type[managed-node3]=witness
-        lsrMssqlHaUpdateInventory "$inventory_external" mssql_ha_replica_type
-        lsrMssqlHaUpdateInventory "$inventory_external_read_only" mssql_ha_replica_type
+        lsrAppendHostVarsToInventory "$inventory_external" mssql_ha_replica_type
+        lsrAppendHostVarsToInventory "$inventory_external_read_only" mssql_ha_replica_type
         unset mssql_ha_replica_type
 
         declare -A mssql_ha_replica_type
         mssql_ha_replica_type[managed-node1]=primary
         mssql_ha_replica_type[managed-node2]=synchronous
-        # mssql_ha_replica_type is used below when calling lsrMssqlHaUpdateInventory
+        # mssql_ha_replica_type is used below when calling lsrAppendHostVarsToInventory
         # shellcheck disable=SC2034
         mssql_ha_replica_type[managed-node3]=asynchronous
-        lsrMssqlHaUpdateInventory "$inventory_read_scale" mssql_ha_replica_type
+        lsrAppendHostVarsToInventory "$inventory_read_scale" mssql_ha_replica_type
 
         # Set mssql_ha_ag_secondary_role_allow_connections variables in inventories
         declare -A mssql_ha_ag_secondary_role_allow_connections
         mssql_ha_ag_secondary_role_allow_connections[managed-node1]=ALL
+        # mssql_ha_ag_secondary_role_allow_connections is used below when calling lsrAppendHostVarsToInventory
+        # shellcheck disable=SC2034
         mssql_ha_ag_secondary_role_allow_connections[managed-node2]=READ_ONLY
-        lsrMssqlHaUpdateInventory "$inventory_external_read_only" mssql_ha_ag_secondary_role_allow_connections
-        unset mssql_ha_replica_type
+        lsrAppendHostVarsToInventory "$inventory_external_read_only" mssql_ha_ag_secondary_role_allow_connections
 
-        # Set mssql_ha_ag_secondary_role_allow_connections variables in inventories
-        declare -A mssql_ha_ag_secondary_role_allow_connections
-        mssql_ha_ag_secondary_role_allow_connections[managed-node1]="('managed_host2')"
-        lsrMssqlHaUpdateInventory "$inventory_external_read_only" mssql_ha_ag_secondary_role_allow_connections
-        unset mssql_ha_replica_type
+        # Set mssql_ha_ag_read_only_routing_list variables in inventories
+        declare -A mssql_ha_ag_read_only_routing_list
+        # mssql_ha_ag_read_only_routing_list is used below when calling lsrAppendHostVarsToInventory
+        # shellcheck disable=SC2034
+        mssql_ha_ag_read_only_routing_list[managed-node1]="('managed-node2')"
+        lsrAppendHostVarsToInventory "$inventory_external_read_only" mssql_ha_ag_read_only_routing_list
 
         # Find the IP of the virtualip node that was shut down
         virtualip_name=$(sed --quiet --regexp-extended 's/^(virtualip.*):/\1/p' "$guests_yml")
@@ -192,7 +194,7 @@ rlJournalStart
                 LOGFILE="${test_playbook_basename%.*}"-ANSIBLE-"$SR_ANSIBLE_VER"-"$tmt_plan"-"$mssql_version"
                 if [ "$test_playbook_basename" = "tests_configure_ha_cluster_external.yml" ]; then
                     lsrRunPlaybook "$test_playbook" "$inventory_external" "$SR_SKIP_TAGS" "" "$LOGFILE" "${SR_ANSIBLE_VERBOSITY:--vv}"
-                if [ "$test_playbook_basename" = "tests_configure_ha_cluster_external_read_only.yml" ]; then
+                elif [ "$test_playbook_basename" = "tests_configure_ha_cluster_external_read_only.yml" ]; then
                     lsrRunPlaybook "$test_playbook" "$inventory_external_read_only" "$SR_SKIP_TAGS" "" "$LOGFILE" "${SR_ANSIBLE_VERBOSITY:--vv}"
                 elif [ "$test_playbook_basename" = "tests_configure_ha_cluster_read_scale.yml" ]; then
                     lsrRunPlaybook "$test_playbook" "$inventory_read_scale" "$SR_SKIP_TAGS" "" "$LOGFILE" "${SR_ANSIBLE_VERBOSITY:--vv}"


### PR DESCRIPTION
## Summary by Sourcery

Add support for an external read-only HA cluster test to the mssql_ha suite and refactor inventory handling to be more generic and configurable

New Features:
- Add tests_configure_ha_cluster_external_read_only.yml and integrate it into the mssql_ha test suite

Enhancements:
- Generalize inventory updates using dynamic array names in lsrMssqlHaUpdateInventory
- Introduce and apply mssql_ha_ag_secondary_role_allow_connections settings in inventories
- Extend virtual IP substitution to both external HA playbooks

Tests:
- Prepare and manage three inventories (external, read_scale, external_read_only) and run corresponding playbooks including the new read-only scenario