### PR TITLE
Fix bug with overwriting SR_ONLY_TESTS in mssql_ha test

### DIFF
--- a/plans/general.fmf
+++ b/plans/general.fmf
@@ -21,9 +21,9 @@ environment:
     ANSIBLE_VER: 2.17
     SR_REPO_NAME: ""
     # new var name: SR_PYTHON_VERSION: 3.12
-    PYTHON_VERSION: 3.12
+    SR_PYTHON_VERSION: 3.12
     # new var name: SR_ONLY_TESTS: ""
-    SYSTEM_ROLES_ONLY_TESTS: ""
+    SR_ONLY_TESTS: ""
     SR_TEST_LOCAL_CHANGES: false
     SR_PR_NUM: ""
     SR_LSR_USER: ""

--- a/plans/mssql_ha.fmf
+++ b/plans/mssql_ha.fmf
@@ -32,12 +32,12 @@ provision:
     pool: aws-testing-farm-09
 environment:
     # new var name: SR_ANSIBLE_VER: 2.17
-    ANSIBLE_VER: 2.17
+    SR_ANSIBLE_VER: 2.17
     # new var name: SR_PYTHON_VERSION: 3.12
-    PYTHON_VERSION: 3.12
+    SR_PYTHON_VERSION: 3.12
     SR_REPO_NAME: mssql
     # new var name: SR_ONLY_TESTS: ""
-    SYSTEM_ROLES_ONLY_TESTS: "tests_configure_ha_cluster_external.yml tests_configure_ha_cluster_read_scale.yml tests_configure_ha_cluster_external_read_only.yml"
+    SR_ONLY_TESTS: "tests_configure_ha_cluster_external.yml tests_configure_ha_cluster_read_scale.yml tests_configure_ha_cluster_external_read_only.yml"
     SR_TEST_LOCAL_CHANGES: false
     SR_PR_NUM: ""
     SR_LSR_USER: ""

--- a/tests/mssql_ha/mssql_ha.sh
+++ b/tests/mssql_ha/mssql_ha.sh
@@ -24,7 +24,7 @@ SR_TEST_LOCAL_CHANGES="${SR_TEST_LOCAL_CHANGES:-false}"
 # SR_ONLY_TESTS
 #  Optional: Space separated names of test playbooks to test. E.g. "tests_imuxsock_files.yml tests_relp.yml"
 #  If empty, tests all tests in tests/tests_*.yml
-SYSTEM_ROLES_ONLY_TESTS="${SYSTEM_ROLES_ONLY_TESTS:-tests_configure_ha_cluster_external.yml tests_configure_ha_cluster_read_scale.yml}"
+SR_ONLY_TESTS="${SR_ONLY_TESTS:-tests_configure_ha_cluster_external.yml tests_configure_ha_cluster_read_scale.yml tests_configure_ha_cluster_external_read_only.yml}"
 [ -n "$SYSTEM_ROLES_ONLY_TESTS" ] && export SR_ONLY_TESTS="$SYSTEM_ROLES_ONLY_TESTS"
 #
 # SR_EXCLUDED_TESTS


### PR DESCRIPTION
## Summary by Sourcery

Fix the test-suite script for mssql_ha to preserve the SR_ONLY_TESTS variable and include an additional read-only HA test playbook by default.

Bug Fixes:
- Prevent SR_ONLY_TESTS from being overwritten by SYSTEM_ROLES_ONLY_TESTS in mssql_ha.sh

Enhancements:
- Add tests_configure_ha_cluster_external_read_only.yml to the default SR_ONLY_TESTS list
- Update FMF plans for general and mssql_ha to reflect the new test playbook