### PR TITLE
ci: Provide order, replace enabling epel with a tmt feature

### DIFF
--- a/plans/general.fmf
+++ b/plans/general.fmf
@@ -35,6 +35,8 @@ environment:
     LSR_TFT_DEBUG: false
 prepare:
   - name: Use vault.centos.org repos (CS 7, 8 EOL workaround)
+    # Providing order to run prep tasks as first because beakerlib is required
+    order: 10
     script: |
       if grep -q 'CentOS Stream release 8' /etc/redhat-release; then
         sed -i '/^mirror/d;s/#\(baseurl=http:\/\/\)mirror/\1vault/' /etc/yum.repos.d/*.repo
@@ -42,15 +44,10 @@ prepare:
       if grep -q 'CentOS Linux release 7.9' /etc/redhat-release; then
         sed -i '/^mirror/d;s/#\?\(baseurl=http:\/\/\)mirror/\1vault/' /etc/yum.repos.d/*.repo
       fi
-  # Replace with feature: epel: enabled once https://github.com/teemtee/tmt/pull/3128 is merged
-  - name: Enable epel to install beakerlib
-    script: |
-      # CS 10 and Fedora doesn't require epel
-      if grep -q -e 'CentOS Stream release 10' -e 'Fedora release' /etc/redhat-release; then
-        exit 0
-      fi
-      yum install epel-release yum-utils -y
-      yum-config-manager --enable epel epel-debuginfo epel-source
+  - name: Enable EPEL to get beakerlib
+    order: 10
+    how: feature
+    epel: enabled
 discover:
   - name: Prepare managed node
     how: fmf

--- a/plans/mssql_ha.fmf
+++ b/plans/mssql_ha.fmf
@@ -49,6 +49,8 @@ environment:
     LSR_TFT_DEBUG: false
 prepare:
   - name: Use vault.centos.org repos (CS 7, 8 EOL workaround)
+    # Providing order to run prep tasks as first because beakerlib is required
+    order: 10
     script: |
       if grep -q 'CentOS Stream release 8' /etc/redhat-release; then
         sed -i '/^mirror/d;s/#\(baseurl=http:\/\/\)mirror/\1vault/' /etc/yum.repos.d/*.repo
@@ -56,15 +58,10 @@ prepare:
       if grep -q 'CentOS Linux release 7.9' /etc/redhat-release; then
         sed -i '/^mirror/d;s/#\?\(baseurl=http:\/\/\)mirror/\1vault/' /etc/yum.repos.d/*.repo
       fi
-  # Replace with feature: epel: enabled once https://github.com/teemtee/tmt/pull/3128 is merged
-  - name: Enable epel to install beakerlib
-    script: |
-      # CS 10 and Fedora doesn't require epel
-      if grep -q -e 'CentOS Stream release 10' -e 'Fedora release' /etc/redhat-release; then
-        exit 0
-      fi
-      yum install epel-release yum-utils -y
-      yum-config-manager --enable epel epel-debuginfo epel-source
+  - name: Enable EPEL to get beakerlib
+    order: 10
+    how: feature
+    epel: enabled
 discover:
   - name: Prepare managed nodes
     how: fmf


### PR DESCRIPTION
Replaced with `feature: epel` because https://github.com/teemtee/tmt/pull/3128 is merged

## Summary by Sourcery

Add explicit ordering to FMF plans and replace manual EPEL repository setup with the TMT 'epel' feature in general and mssql_ha plans

CI:
- Provide explicit order definitions in general and mssql_ha FMF plans to control test execution sequence
- Replace manual EPEL enabling with the built-in TMT 'epel' feature in FMF plans