### PR TITLE
Update the use of lsrGenerateTestDisks

### DIFF
--- a/tests/general/test.sh
+++ b/tests/general/test.sh
@@ -129,7 +129,6 @@ rlJournalStart
         # role_path is defined in lsrGetRoleDir
         # shellcheck disable=SC2154
         legacy_test_path="$role_path"/tests
-        lsrGenerateTestDisks "$legacy_test_path" start disk_provisioner.sh
         test_playbooks=$(lsrGetTests "$legacy_test_path")
         rlLogInfo "Test playbooks: $test_playbooks"
         if lsrVaultRequired "$legacy_test_path"; then
@@ -151,9 +150,13 @@ rlJournalStart
             # shellcheck disable=SC2086
             lsrSetupGetPythonModules "$test_playbooks"
         fi
+
+        managed_nodes=$(lsrGetManagedNodes)
+        for managed_node in $managed_nodes; do
+            lsrGenerateTestDisks "$tests_path" start disk_provisioner.sh "$managed_node"
+        done
     rlPhaseEnd
     rlPhaseStartTest
-        managed_nodes=$(lsrGetManagedNodes)
         lsrRunPlaybooksParallel "$SR_SKIP_TAGS" "$test_playbooks" "$managed_nodes" "false" "$SR_ANSIBLE_VERBOSITY"
         lsrSubmitManagedNodesLogs
         lsrReserveSystems "$SR_RESERVE_SYSTEMS"


### PR DESCRIPTION
## Summary by Sourcery

Refactor test.sh to provision test disks for each managed node using the new lsrGenerateTestDisks invocation and remove the legacy single-call provisioning.

Enhancements:
- Remove legacy lsrGenerateTestDisks call on the old tests directory
- Loop over each managed node and call lsrGenerateTestDisks with the new tests_path and node argument