### PR TITLE
Fix getting node name by making regex more strict

### DIFF
--- a/library/upstream_library/lib.sh
+++ b/library/upstream_library/lib.sh
@@ -304,7 +304,7 @@ lsrGetNodeName() {
 lsrGetCurrNodeHostname() {
     local ip_addr
     ip_addr=$(hostname -I | awk '{print $1}')
-    grep "primary-address: $ip_addr" "$GUESTS_YML" -B 10 | sed --quiet --regexp-extended 's/(^[^ ]*):$/\1/p'
+    grep "primary-address: $ip_addr$" "$GUESTS_YML" -B 10 | sed --quiet --regexp-extended 's/(^[^ ]*):$/\1/p'
 }
 
 lsrGetNodeIp() {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Anchor the IP address match in grep to prevent partial or unintended matches when fetching the current node hostname.