### PR TITLE
ci: use python 3.14 on Fedora 43 and later

### DIFF
--- a/library/upstream_library/lib.sh
+++ b/library/upstream_library/lib.sh
@@ -26,7 +26,9 @@ lsrLabBosRepoWorkaround() {
 
 lsrInstallAnsible() {
     # Hardcode to the only supported version on later ELs
-    if rlIsFedora '>=41'; then
+    if rlIsFedora '>=43'; then
+        SR_PYTHON_VERSION=3.14
+    elif rlIsFedora '>=41'; then
         SR_PYTHON_VERSION=3.13
     elif rlIsRHELLike 8 && [ "$SR_ANSIBLE_VER" == "2.9" ]; then
         SR_PYTHON_VERSION=3.9


### PR DESCRIPTION
The system python version on Fedora 32 is 3.14

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Enhancements:
- Set Python 3.14 as the system Python for Fedora 43 and later while keeping Fedora 41–42 on Python 3.13 for Ansible installation logic.