### PR TITLE
ci: do not install Ansible pre-releases by default

### DIFF
--- a/library/upstream_library/lib.sh
+++ b/library/upstream_library/lib.sh
@@ -45,7 +45,7 @@ lsrInstallAnsible() {
         # install ansible dependencies first so that we do not install pre-release versions of them
         rlRun "python$SR_PYTHON_VERSION -m pip install passlib"
         # install possible pre-release version of ansible-core
-        rlRun "python$SR_PYTHON_VERSION -m pip install --pre 'ansible-core==$SR_ANSIBLE_VER.*'"
+        rlRun "python$SR_PYTHON_VERSION -m pip install $SR_ANSIBLE_VER_PRE_RELEASE 'ansible-core==$SR_ANSIBLE_VER.*'"
     elif rlIsRHELLike 8; then
         # el8 ansible-2.9
         rlRun "dnf install python$SR_PYTHON_VERSION -y"

--- a/plans/general.fmf
+++ b/plans/general.fmf
@@ -29,6 +29,7 @@ environment:
     SR_ARTIFACTS_DIR: ""
     SR_ARTIFACTS_URL: ""
     SR_TFT_DEBUG: false
+    SR_ANSIBLE_VER_PRE_RELEASE: ""  # set to "--pre" to use a pre-release version of Ansible
 prepare:
   - name: Use vault.centos.org repos (CS 7, 8 EOL workaround)
     # Providing order to run prep tasks as first because beakerlib is required

--- a/plans/mssql_ha.fmf
+++ b/plans/mssql_ha.fmf
@@ -43,6 +43,7 @@ environment:
     SR_ARTIFACTS_DIR: ""
     SR_ARTIFACTS_URL: ""
     SR_TFT_DEBUG: false
+    SR_ANSIBLE_VER_PRE_RELEASE: ""  # set to "--pre" to use a pre-release version of Ansible
 prepare:
   - name: Use vault.centos.org repos (CS 7, 8 EOL workaround)
     # Providing order to run prep tasks as first because beakerlib is required

--- a/plans/test_playbooks_parallel_local.fmf
+++ b/plans/test_playbooks_parallel_local.fmf
@@ -31,6 +31,7 @@ environment:
     SR_ARTIFACTS_DIR: ""
     SR_ARTIFACTS_URL: ""
     SR_TFT_DEBUG: false
+    SR_ANSIBLE_VER_PRE_RELEASE: ""  # set to "--pre" to use a pre-release version of Ansible
 prepare:
   - name: Use vault.centos.org repos (CS 7, 8 EOL workaround)
     # Providing order to run prep tasks as first because beakerlib is required


### PR DESCRIPTION
Use `SR_ANSIBLE_VER_PRE_RELEASE: "--pre"` to install Ansible pre-releases

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Enhancements:
- Add support for configuring whether Ansible pre-release versions are installed by passing a dedicated pre-release flag into the pip install command.