### PR TITLE
must use ansible.posix 2.1.0 for now

### DIFF
--- a/library/upstream_library/lib.sh
+++ b/library/upstream_library/lib.sh
@@ -226,7 +226,7 @@ lsrEnableCallbackPlugins() {
     callback_path=ansible_collections/ansible/posix/plugins/callback
     if [ ! -f "$collection_path"/"$callback_path"/debug.py ] || [ ! -f "$collection_path"/"$callback_path"/profile_tasks.py ]; then
         ansible_posix=$(mktemp --directory -t ansible_posix-XXX)
-        cmd="ansible-galaxy collection install ansible.posix -p $ansible_posix -vv"
+        cmd="ansible-galaxy collection install ansible.posix==$SR_ANSIBLE_POSIX_VERSION -p $ansible_posix -vv"
         if lsrIsAnsibleCmdOptionSupported "ansible-galaxy collection install" "--force-with-deps"; then
             rlWaitForCmd "$cmd --force-with-deps" -m 5
         elif lsrIsAnsibleCmdOptionSupported "ansible-galaxy collection install" "--force"; then

--- a/tests/general/test.sh
+++ b/tests/general/test.sh
@@ -108,6 +108,10 @@ SR_ANSIBLE_INJECT_FACT_VARS="${SR_ANSIBLE_INJECT_FACT_VARS:-false}"
 #   TMT sets True, False with capital letters, need to reset it to bash style
 [ "$SR_ANSIBLE_INJECT_FACT_VARS" = True ] && export SR_ANSIBLE_INJECT_FACT_VARS=true
 [ "$SR_ANSIBLE_INJECT_FACT_VARS" = False ] && export SR_ANSIBLE_INJECT_FACT_VARS=false
+# SR_ANSIBLE_POSIX_VERSION
+#   Version of ansible.posix collection to install
+#   We currently cannot use 2.2.0 because it is not compatible with el7
+SR_ANSIBLE_POSIX_VERSION="${SR_ANSIBLE_POSIX_VERSION:-2.1.0}"
 
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo "~~~ Environment Variables Definition - BEGIN"


### PR DESCRIPTION
ansible.posix 2.2.0 does not work with el7, so restrict
version to 2.1.0 for now.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Pin the ansible.posix collection version used by test tooling to a specific compatible release for EL7 systems.

Build:
- Introduce SR_ANSIBLE_POSIX_VERSION environment variable defaulting to ansible.posix 2.1.0 for test runs.
- Update ansible-galaxy collection install command to install ansible.posix at the configured version instead of the latest.